### PR TITLE
Implement Shadowsocks proxy extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # ShadowChrome
+
+This repository contains a Chrome extension and companion native messaging host implementing a Shadowsocks proxy for browser-only traffic. The extension allows importing Shadowsocks configuration keys, selecting available servers, and managing the connection from the popup UI.
+
+## Structure
+
+- `manifest.json` – Chrome extension manifest (Manifest V3).
+- `popup.html`, `popup.js`, `popup.css` – Popup UI resources.
+- `background.js` – Background service worker handling communication with the native host and proxy configuration.
+- `native_host/` – Example Python implementation of the Chrome native messaging host.
+
+## Native Host Setup
+
+The Python host expects the `ss-local` executable from a Shadowsocks client to be installed and available in `PATH`. Register the host using the provided `shadowchrome_host.json` file and Chrome's native messaging manifest procedure.
+
+When a connection is established the extension configures Chrome to use a local SOCKS5 proxy on `127.0.0.1:1080`. Disconnecting or logging out restores the previous proxy settings.
+
+## Example Configuration Keys
+
+```
+ss://YWVzLTI1Ni1nY206cGFzc3dvcmQ=@example.com:8388#ExampleServer
+{"servers":[{"name":"Test","server":"example.com","port":8388,"method":"aes-256-gcm","password":"password"}]}
+```
+
+These are placeholders; replace them with real server information.
+
+## Development
+
+1. Load the extension unpacked in Chrome via **chrome://extensions**.
+2. Register the native host (see `native_host/README.md`).
+3. Open the extension popup, import a configuration key (supports `ss://`, `sconf://`, `ssconf://`, or `outline://`), and connect.
+

--- a/background.js
+++ b/background.js
@@ -1,0 +1,41 @@
+let processRunning = false;
+
+function sendNative(message) {
+  return new Promise((resolve) => {
+    chrome.runtime.sendNativeMessage(
+      'com.example.shadowchrome',
+      message,
+      resolve
+    );
+  });
+}
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.action === 'connect') {
+    sendNative({ action: 'connect', server: msg.server }).then((res) => {
+      processRunning = true;
+      chrome.proxy.settings.set({
+        value: {
+          mode: 'fixed_servers',
+          rules: {
+            singleProxy: { scheme: 'socks5', host: '127.0.0.1', port: 1080 },
+            bypassList: ['<local>']
+          }
+        }
+      });
+      chrome.runtime.sendMessage({ status: res && res.status ? res.status : 'Connected' });
+    });
+  } else if (msg.action === 'disconnect') {
+    sendNative({ action: 'disconnect' }).then((res) => {
+      processRunning = false;
+      chrome.proxy.settings.clear({}, () => {});
+      chrome.runtime.sendMessage({ status: res && res.status ? res.status : 'Disconnected' });
+    });
+  } else if (msg.action === 'logout') {
+    sendNative({ action: 'logout' }).then((res) => {
+      processRunning = false;
+      chrome.proxy.settings.clear({}, () => {});
+      chrome.runtime.sendMessage({ status: res && res.status ? res.status : 'Disconnected' });
+    });
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,14 @@
+{
+  "manifest_version": 3,
+  "name": "ShadowChrome",
+  "description": "Browser-only Shadowsocks proxy via native messaging.",
+  "version": "0.1",
+  "action": {
+    "default_title": "ShadowChrome",
+    "default_popup": "popup.html"
+  },
+  "permissions": ["storage", "proxy", "nativeMessaging"],
+  "background": {
+    "service_worker": "background.js"
+  }
+}

--- a/native_host/README.md
+++ b/native_host/README.md
@@ -1,0 +1,12 @@
+# Native Messaging Host
+
+The Python script `shadowchrome_host.py` acts as the native host for the Chrome extension. It must be registered with Chrome using a manifest file.
+
+1. Replace `__HOST_PATH__` in `shadowchrome_host.json` with the absolute path to `shadowchrome_host.py`.
+2. Replace `__EXT_ID__` with the extension's ID once installed unpacked.
+3. Copy the manifest to the platform-specific location:
+   - **Windows:** `%LOCALAPPDATA%\Google\Chrome\User Data\NativeMessagingHosts`.
+   - **Linux:** `~/.config/google-chrome/NativeMessagingHosts`.
+4. Ensure `ss-local` from a Shadowsocks client is installed and in `PATH`.
+
+The host listens for JSON messages from the extension to start or stop `ss-local` using the provided server configuration.

--- a/native_host/shadowchrome_host.json
+++ b/native_host/shadowchrome_host.json
@@ -1,0 +1,7 @@
+{
+  "name": "com.example.shadowchrome",
+  "description": "ShadowChrome native messaging host",
+  "path": "__HOST_PATH__",
+  "type": "stdio",
+  "allowed_origins": ["chrome-extension://__EXT_ID__/"]
+}

--- a/native_host/shadowchrome_host.py
+++ b/native_host/shadowchrome_host.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+import sys
+import json
+import subprocess
+
+proc = None
+
+def read_message():
+    raw_length = sys.stdin.buffer.read(4)
+    if not raw_length:
+        return None
+    length = int.from_bytes(raw_length, byteorder='little')
+    data = sys.stdin.buffer.read(length)
+    return json.loads(data.decode('utf-8'))
+
+def send_message(msg):
+    encoded = json.dumps(msg).encode('utf-8')
+    sys.stdout.buffer.write(len(encoded).to_bytes(4, 'little'))
+    sys.stdout.buffer.write(encoded)
+    sys.stdout.buffer.flush()
+
+while True:
+    msg = read_message()
+    if msg is None:
+        break
+    action = msg.get('action')
+    if action == 'connect':
+        if proc:
+            proc.terminate()
+        s = msg['server']
+        cmd = [
+            'ss-local', '-s', s['server'], '-p', str(s['port']),
+            '-k', s['password'], '-m', s['method'],
+            '-b', '127.0.0.1', '-l', '1080'
+        ]
+        proc = subprocess.Popen(cmd)
+        send_message({'status': 'Connected'})
+    elif action in ('disconnect', 'logout'):
+        if proc:
+            proc.terminate()
+            proc.wait()
+            proc = None
+        send_message({'status': 'Disconnected'})

--- a/popup.css
+++ b/popup.css
@@ -1,0 +1,30 @@
+body {
+  font-family: Arial, sans-serif;
+  width: 350px;
+  padding: 10px;
+}
+.hidden { display: none; }
+.row { margin-bottom: 10px; }
+button {
+  padding: 5px 10px;
+  border: none;
+  border-radius: 4px;
+  background: #4a90e2;
+  color: #fff;
+  cursor: pointer;
+  margin-right: 5px;
+}
+button:hover { background: #357ab8; }
+.error { color: red; margin-top: 5px; }
+.status { margin: 10px 0; font-weight: bold; }
+.status.disconnected { color: #b00; }
+.status.connected { color: #0a0; }
+@keyframes pulse {
+  0% { opacity: 1; }
+  50% { opacity: 0.4; }
+  100% { opacity: 1; }
+}
+.status.connecting {
+  color: #e90;
+  animation: pulse 1s infinite;
+}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ShadowChrome</title>
+<link rel="stylesheet" href="popup.css">
+</head>
+<body>
+<div id="loginView">
+  <h1 id="extensionName">ShadowChrome</h1>
+  <input type="text" id="configKey" placeholder="Paste config key">
+  <button id="importBtn">Import</button>
+  <div id="loginError" class="error"></div>
+</div>
+<div id="mainView" class="hidden">
+  <div class="row">
+    <label for="serverSelect">Server:</label>
+    <select id="serverSelect"></select>
+  </div>
+  <div id="status" class="status disconnected">Disconnected</div>
+  <button id="connectBtn">Connect</button>
+  <button id="disconnectBtn" class="hidden">Disconnect</button>
+  <button id="logoutBtn">Logout</button>
+</div>
+<script src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,111 @@
+const loginView = document.getElementById('loginView');
+const mainView = document.getElementById('mainView');
+const configInput = document.getElementById('configKey');
+const importBtn = document.getElementById('importBtn');
+const loginError = document.getElementById('loginError');
+const serverSelect = document.getElementById('serverSelect');
+const statusEl = document.getElementById('status');
+const connectBtn = document.getElementById('connectBtn');
+const disconnectBtn = document.getElementById('disconnectBtn');
+const logoutBtn = document.getElementById('logoutBtn');
+
+function show(view) {
+  loginView.classList.add('hidden');
+  mainView.classList.add('hidden');
+  view.classList.remove('hidden');
+}
+
+async function parseKey(key) {
+  if (key.startsWith('ss://')) {
+    const cleaned = key.replace('ss://', '').split('#')[0];
+    const [userinfo, hostinfo] = cleaned.split('@');
+    const [method, password] = atob(userinfo).split(':');
+    const [server, port] = hostinfo.split(':');
+    return [{ name: server, server, port, method, password }];
+  }
+  const lower = key.toLowerCase();
+  if (lower.startsWith('sconf://') || lower.startsWith('ssconf://') || lower.startsWith('outline://')) {
+    const cleaned = key.replace(/^[a-zA-Z]+:\/\//, '');
+    const fetchUrl = cleaned.startsWith('http') ? cleaned : 'https://' + cleaned;
+    const res = await fetch(fetchUrl);
+    const data = await res.json();
+    return data.servers || [];
+  }
+  try {
+    const data = JSON.parse(atob(key));
+    return data.servers || [];
+  } catch (e) {
+    throw new Error('Invalid key');
+  }
+}
+
+async function loadProfile() {
+  const data = await chrome.storage.local.get(['servers', 'selected']);
+  if (data.servers) {
+    populateServers(data.servers, data.selected);
+    show(mainView);
+  }
+}
+
+function populateServers(servers, selected) {
+  serverSelect.innerHTML = '';
+  servers.forEach((s, i) => {
+    const opt = document.createElement('option');
+    opt.value = i;
+    opt.textContent = s.name || s.server;
+    if (selected === i) opt.selected = true;
+    serverSelect.appendChild(opt);
+  });
+}
+
+importBtn.addEventListener('click', async () => {
+  loginError.textContent = '';
+  try {
+    const servers = await parseKey(configInput.value.trim());
+    await chrome.storage.local.set({ servers, selected: 0 });
+    populateServers(servers, 0);
+    show(mainView);
+  } catch (e) {
+    loginError.textContent = e.message;
+  }
+});
+
+serverSelect.addEventListener('change', () => {
+  const idx = parseInt(serverSelect.value, 10);
+  chrome.storage.local.set({ selected: idx });
+});
+
+connectBtn.addEventListener('click', async () => {
+  const idx = parseInt(serverSelect.value, 10);
+  const servers = (await chrome.storage.local.get('servers')).servers;
+  const server = servers[idx];
+  await chrome.storage.local.set({ selected: idx });
+  statusEl.textContent = 'Connecting...';
+  statusEl.className = 'status connecting';
+  connectBtn.classList.add('hidden');
+  disconnectBtn.classList.remove('hidden');
+  chrome.runtime.sendMessage({ action: 'connect', server });
+});
+
+disconnectBtn.addEventListener('click', () => {
+  chrome.runtime.sendMessage({ action: 'disconnect' });
+  statusEl.textContent = 'Disconnected';
+  statusEl.className = 'status disconnected';
+  disconnectBtn.classList.add('hidden');
+  connectBtn.classList.remove('hidden');
+});
+
+logoutBtn.addEventListener('click', async () => {
+  await chrome.storage.local.clear();
+  chrome.runtime.sendMessage({ action: 'logout' });
+  show(loginView);
+});
+
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.status) {
+    statusEl.textContent = msg.status;
+    statusEl.className = 'status ' + msg.status.toLowerCase();
+  }
+});
+
+loadProfile();


### PR DESCRIPTION
## Summary
- set up Chrome extension manifest and popup UI
- implement logic for config key import, connecting, and disconnecting
- add background service worker for native messaging
- provide Python native host to run `ss-local`
- document usage and example configuration keys
- refine proxy handling and server selection persistence

## Testing
- `node --check popup.js`
- `node --check background.js`
- `python3 -m py_compile native_host/shadowchrome_host.py`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688b45b9f9d883228862605fef0bfe3c