### PR TITLE
feat: add location selection and streamline config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ShadowChrome
 
-ShadowChrome is a Chrome extension that aims to provide a fully self-contained Shadowsocks client. Users supply an `ss://` or `ssconf://` key and the extension handles the rest from inside the browser.
+ShadowChrome is a Chrome extension that aims to provide a fully self-contained Shadowsocks client. Users supply an `ss://` or `ssconf://` key and the extension fetches available server locations from the Shadowsocks network before handling the rest inside the browser.
 
 > **Status:** The legacy Node.js helper server has been removed. The service worker parses configuration links and configures Chrome's proxy settings. Running the Shadowsocks client via `chrome.sockets` is still a TODO.
 
@@ -10,9 +10,10 @@ ShadowChrome is a Chrome extension that aims to provide a fully self-contained S
 
 ## Usage
 1. Click the ShadowChrome icon.
-2. Paste an `ss://` or `ssconf://` access key and optionally change the local port (defaults to `1080`).
-3. Press **Connect** to save the settings and set Chrome's proxy to `127.0.0.1:<port>`.
-4. Press **Disconnect** to clear the proxy configuration.
+2. Paste an `ss://` or `ssconf://` access key. The extension will retrieve any advertised servers from the Shadowsocks network.
+3. If multiple servers are returned, choose a location.
+4. Press **Connect** to save the settings and set Chrome's proxy to `127.0.0.1:1080`.
+5. Press **Disconnect** to clear the proxy configuration.
 
 ## Development
 - All extension code resides in `src/`.
@@ -20,7 +21,7 @@ ShadowChrome is a Chrome extension that aims to provide a fully self-contained S
 - Execute `npm run lint` to check code style.
 
 ## Architecture
-- `popup.html` / `popup.js` provide a small HTML/CSS interface.
+- `popup.html` / `popup.js` provide a small HTML/CSS interface with optional location selection.
 - `ssConfig.js` parses `ss://` and `ssconf://` URLs.
 - `background.js` (service worker) applies proxy settings and will host the Shadowsocks client using `chrome.sockets`.
 

--- a/docs/DETAILED_DOCUMENTATION.md
+++ b/docs/DETAILED_DOCUMENTATION.md
@@ -22,12 +22,12 @@ third_party/
 ```
 
 ### `popup.html` / `popup.js`
-Provides a small HTML interface styled entirely with CSS. Users paste an access URL and optionally select a local port. When **Connect** is pressed the popup calls `parseAccessUrl()` and sends the resulting configuration to the background script.
+Provides a small HTML interface styled entirely with CSS. Users paste an access URL and, if multiple servers are offered, select a location. When **Connect** is pressed the popup calls `parseAccessUrl()` and sends the resulting configuration to the background script.
 
 ### `ssConfig.js`
 Exports two helpers:
-- `parseAccessUrl(url)` – accepts both `ss://` and `ssconf://` schemes. The latter is fetched via HTTPS and may return JSON or a bare `ss://` string.
-- `parseSsUrl(url)` – decodes an `ss://` link into `{method, password, host, port}`.
+- `parseAccessUrl(url)` – accepts both `ss://` and `ssconf://` schemes. If the link points to an online subscription the remote document is fetched (via HTTPS) and parsed, returning every advertised server and its tag.
+- `parseSsUrl(url)` – decodes an `ss://` link into `{method, password, host, port}` and preserves the optional `#tag` suffix as `tag`.
 
 ### `background.js`
 Listens for messages from the popup. On `start-proxy` it stores the configuration and sets Chrome's proxy settings to `socks5://127.0.0.1:<localPort>`. On `stop-proxy` it clears the proxy configuration. The TODO section is where the Shadowsocks client will be started and stopped using `chrome.sockets`.
@@ -35,8 +35,8 @@ Listens for messages from the popup. On `start-proxy` it stores the configuratio
 ## Running the Extension
 1. Enable Developer mode at `chrome://extensions/`.
 2. Load the `src` directory as an unpacked extension.
-3. Open the popup, enter your access key and port, and click **Connect**.
-4. Chrome's proxy settings will point to `127.0.0.1:<port>`.
+3. Open the popup, enter your access key, pick a location if prompted, and click **Connect**.
+4. Chrome's proxy settings will point to `127.0.0.1:1080`.
 
 ## Future Work
 - Implement the Shadowsocks client inside `background.js` using JavaScript or WebAssembly and `chrome.sockets`.

--- a/src/popup.html
+++ b/src/popup.html
@@ -6,13 +6,13 @@
   <style>
     body { width: 200px; font-family: sans-serif; padding: 10px; }
     label { display: block; margin-top: 5px; }
-    input { width: 100%; }
+    input, select { width: 100%; }
     button { margin-top: 10px; width: 100%; }
   </style>
 </head>
 <body>
   <label>Access URL <input id="url" type="text" placeholder="ss:// or ssconf://"></label>
-  <label>Local Port <input id="port" type="number" value="1080"></label>
+  <label id="location-label" style="display:none;">Location <select id="location"></select></label>
   <button id="connect">Connect</button>
   <button id="disconnect">Disconnect</button>
   <pre id="status"></pre>

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,30 +1,67 @@
 import { parseAccessUrl } from './ssConfig.js';
 
+let parsedConfigs = null;
+
 function loadConfig() {
-  chrome.storage.local.get(['accessUrl', 'localPort'], (cfg) => {
-    if (cfg.localPort) {
-      document.getElementById('port').value = cfg.localPort;
-    }
+  chrome.storage.local.get(['accessUrl'], (cfg) => {
     if (cfg.accessUrl) {
       document.getElementById('url').value = cfg.accessUrl;
     }
   });
 }
 
+function showLocations(configs) {
+  const label = document.getElementById('location-label');
+  const select = document.getElementById('location');
+  select.innerHTML = '';
+  configs.forEach((cfg, i) => {
+    const option = document.createElement('option');
+    option.value = i;
+    option.textContent = cfg.tag || cfg.name || cfg.host;
+    select.appendChild(option);
+  });
+  label.style.display = 'block';
+}
+
 document.addEventListener('DOMContentLoaded', loadConfig);
 
+document.getElementById('url').addEventListener('input', () => {
+  parsedConfigs = null;
+  document.getElementById('location-label').style.display = 'none';
+});
+
 document.getElementById('connect').addEventListener('click', async () => {
-  const port = document.getElementById('port').value || '1080';
   const url = document.getElementById('url').value.trim();
   const status = document.getElementById('status');
+  const locSelect = document.getElementById('location');
   status.textContent = 'Starting proxy...';
   try {
+    if (parsedConfigs && Array.isArray(parsedConfigs)) {
+      const chosen = parsedConfigs[parseInt(locSelect.value, 10)];
+      const finalCfg = { ...chosen, localPort: 1080, accessUrl: url };
+      chrome.storage.local.set(finalCfg);
+      chrome.runtime.sendMessage({ type: 'start-proxy', config: finalCfg }, (response) => {
+        if (response && response.success) {
+          status.textContent = 'Proxy running on 127.0.0.1:1080';
+        } else {
+          status.textContent = 'Error: ' + (response && response.error);
+        }
+      });
+      return;
+    }
+
     const cfg = await parseAccessUrl(url);
-    const finalCfg = { ...cfg, localPort: parseInt(port, 10), accessUrl: url };
+    if (Array.isArray(cfg)) {
+      parsedConfigs = cfg;
+      showLocations(cfg);
+      status.textContent = 'Select location and press Connect';
+      return;
+    }
+    const finalCfg = { ...cfg, localPort: 1080, accessUrl: url };
     chrome.storage.local.set(finalCfg);
     chrome.runtime.sendMessage({ type: 'start-proxy', config: finalCfg }, (response) => {
       if (response && response.success) {
-        status.textContent = 'Proxy running on 127.0.0.1:' + port;
+        status.textContent = 'Proxy running on 127.0.0.1:1080';
       } else {
         status.textContent = 'Error: ' + (response && response.error);
       }

--- a/src/ssConfig.js
+++ b/src/ssConfig.js
@@ -1,30 +1,23 @@
 export async function parseAccessUrl(url) {
   if (url.startsWith('ssconf://')) {
     const onlineUrl = url.replace(/^ssconf:\/\//, 'https://');
-    const res = await fetch(onlineUrl);
-    if (!res.ok) {
-      throw new Error('Failed to fetch config');
-    }
-    let text = (await res.text()).trim();
-    if (text.startsWith('ss://')) {
-      return parseSsUrl(text);
-    }
-    const obj = JSON.parse(text);
-    if (obj.accessUrl) {
-      return parseSsUrl(obj.accessUrl);
-    }
-    throw new Error('Invalid config response');
+    return fetchConfig(onlineUrl);
   }
-  return parseSsUrl(url);
+  if (url.startsWith('ss://')) {
+    return parseSsUrl(url);
+  }
+  throw new Error('Unsupported access url');
 }
 
-export function parseSsUrl(url) {
+export async function parseSsUrl(url) {
   if (!url.startsWith('ss://')) {
     throw new Error('Invalid ss url');
   }
   let rest = url.slice(5);
+  let tag;
   const hashIndex = rest.indexOf('#');
   if (hashIndex !== -1) {
+    tag = decodeURIComponent(rest.substring(hashIndex + 1));
     rest = rest.substring(0, hashIndex);
   }
   let decoded;
@@ -33,8 +26,86 @@ export function parseSsUrl(url) {
   } catch (e) {
     decoded = rest;
   }
+  if (/^(https?:\/\/|ssconf:\/\/)/.test(decoded)) {
+    const onlineUrl = decoded.startsWith('ssconf://')
+      ? decoded.replace(/^ssconf:\/\//, 'https://')
+      : decoded;
+    return fetchConfig(onlineUrl);
+  }
   const [methodPwd, hostPort] = decoded.split('@');
   const [method, password] = methodPwd.split(':');
   const [host, port] = hostPort.split(':');
-  return { method, password, host, port: parseInt(port, 10) };
+  const cfg = { method, password, host, port: parseInt(port, 10) };
+  if (tag) {
+    cfg.tag = tag;
+  }
+  return cfg;
+}
+
+async function fetchConfig(onlineUrl) {
+  const res = await fetch(onlineUrl);
+  if (!res.ok) {
+    throw new Error('Failed to fetch config');
+  }
+  let text = (await res.text()).trim();
+  try {
+    const maybe = atob(text);
+    if (maybe.includes('ss://') || maybe.trim().startsWith('{') || maybe.trim().startsWith('[')) {
+      text = maybe.trim();
+    }
+  } catch (e) {
+    // not base64, ignore
+  }
+  if (text.startsWith('ss://') || text.includes('ss://')) {
+    const urls = text.split(/\s+/).filter((u) => u.startsWith('ss://'));
+    const results = [];
+    for (const u of urls) {
+      const parsed = await parseSsUrl(u);
+      if (Array.isArray(parsed)) {
+        results.push(...parsed);
+      } else {
+        results.push(parsed);
+      }
+    }
+    return results;
+  }
+  const obj = JSON.parse(text);
+  const list = Array.isArray(obj) ? obj : obj.servers || obj.configs;
+  if (Array.isArray(list)) {
+    const results = [];
+    for (const entry of list) {
+      if (entry.accessUrl) {
+        const parsed = await parseAccessUrl(entry.accessUrl);
+        if (Array.isArray(parsed)) {
+          parsed.forEach((p) => {
+            if (entry.tag || entry.name) {
+              p.tag = entry.tag || entry.name;
+            }
+            results.push(p);
+          });
+        } else {
+          if (entry.tag || entry.name) {
+            parsed.tag = entry.tag || entry.name;
+          }
+          results.push(parsed);
+        }
+      } else {
+        const parsed = {
+          method: entry.method,
+          password: entry.password,
+          host: entry.host,
+          port: parseInt(entry.port, 10)
+        };
+        if (entry.tag || entry.name) {
+          parsed.tag = entry.tag || entry.name;
+        }
+        results.push(parsed);
+      }
+    }
+    return results;
+  }
+  if (obj.accessUrl) {
+    return parseAccessUrl(obj.accessUrl);
+  }
+  throw new Error('Invalid config response');
 }


### PR DESCRIPTION
## Summary
- let users pick a location when multiple servers exist
- remove manual local port entry; use default 1080
- document simplified usage and multi-server support
- load server locations from online subscriptions for ss:// and ssconf:// keys

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e6a69d20483229ce7663d5a8cc36c