### PR TITLE
Add registry-driven PAC proxy and cross-browser support

### DIFF
--- a/src/browser-api.js
+++ b/src/browser-api.js
@@ -1,0 +1,33 @@
+export const isFirefox =
+  typeof globalThis.browser !== 'undefined' && !!globalThis.browser.runtime;
+export const isChrome =
+  typeof globalThis.chrome !== 'undefined' && !!globalThis.chrome.runtime && !isFirefox;
+
+export const browser = isFirefox ? globalThis.browser : globalThis.chrome;
+
+// Utility wrappers used across the project to provide consistent Promise-based
+// APIs regardless of whether the underlying implementation uses callbacks.
+
+export function asyncMessage(message) {
+  return new Promise(resolve => {
+    browser.runtime.sendMessage(message, resolve);
+  });
+}
+
+export function getFromStorage(keys) {
+  return new Promise(resolve => {
+    browser.storage.local.get(keys, resolve);
+  });
+}
+
+export function setInStorage(obj) {
+  return new Promise(resolve => {
+    browser.storage.local.set(obj, resolve);
+  });
+}
+
+export function removeFromStorage(keys) {
+  return new Promise(resolve => {
+    browser.storage.local.remove(keys, resolve);
+  });
+}

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,94 @@
+export const LANGS = {
+  en: {
+    name: 'English',
+    flag: '🇺🇸',
+    strings: {
+      languageLabel: 'Language',
+      accessUrlLabel: 'Access URL',
+      accessUrlPlaceholder: 'ss:// or ssconf://',
+      locationLabel: 'Location',
+      connectBtn: 'Connect',
+      disconnectBtn: 'Disconnect',
+      statusStarting: 'Starting proxy...',
+      statusRunning: 'Proxy running on 127.0.0.1:1080',
+      statusError: 'Error:',
+      statusSelectLocation: 'Select location and press Connect',
+      statusFailed: 'Failed to start proxy',
+      statusStopping: 'Stopping...',
+      statusStopped: 'Proxy stopped',
+      proxyDomainsHeading: 'Proxy Domains',
+      domainPlaceholder: 'example.com',
+      addDomainBtn: 'Add Domain'
+    }
+  },
+  lv: {
+    name: 'Latviešu',
+    flag: '🇱🇻',
+    strings: {
+      languageLabel: 'Valoda',
+      accessUrlLabel: 'Piekļuves URL',
+      accessUrlPlaceholder: 'ss:// vai ssconf://',
+      locationLabel: 'Atrašanās vieta',
+      connectBtn: 'Savienot',
+      disconnectBtn: 'Atvienot',
+      statusStarting: 'Startē proxy...',
+      statusRunning: 'Proxy darbojas 127.0.0.1:1080',
+      statusError: 'Kļūda:',
+      statusSelectLocation: 'Izvēlies atrašanās vietu un spied Savienot',
+      statusFailed: 'Neizdevās palaist proxy',
+      statusStopping: 'Apstādināšana...',
+      statusStopped: 'Proxy apstādināts',
+      proxyDomainsHeading: 'Proxy domēni',
+      domainPlaceholder: 'example.com',
+      addDomainBtn: 'Pievienot domēnu'
+    }
+  },
+  be: {
+    name: 'Беларуская',
+    flag: '🇧🇾',
+    strings: {
+      languageLabel: 'Мова',
+      accessUrlLabel: 'URL доступу',
+      accessUrlPlaceholder: 'ss:// або ssconf://',
+      locationLabel: 'Лакацыя',
+      connectBtn: 'Падключыць',
+      disconnectBtn: 'Адключыць',
+      statusStarting: 'Запуск проксі...',
+      statusRunning: 'Проксі працуе на 127.0.0.1:1080',
+      statusError: 'Памылка:',
+      statusSelectLocation: 'Абярыце лакацыю і націсніце Падключыць',
+      statusFailed: 'Не ўдалося запусціць проксі',
+      statusStopping: 'Спыненне...',
+      statusStopped: 'Проксі спынены',
+      proxyDomainsHeading: 'Проксі дамены',
+      domainPlaceholder: 'example.com',
+      addDomainBtn: 'Дадаць дамен'
+    }
+  },
+  de: {
+    name: 'Deutsch',
+    flag: '🇩🇪',
+    strings: {
+      languageLabel: 'Sprache',
+      accessUrlLabel: 'Zugangs-URL',
+      accessUrlPlaceholder: 'ss:// oder ssconf://',
+      locationLabel: 'Standort',
+      connectBtn: 'Verbinden',
+      disconnectBtn: 'Trennen',
+      statusStarting: 'Proxy wird gestartet...',
+      statusRunning: 'Proxy läuft auf 127.0.0.1:1080',
+      statusError: 'Fehler:',
+      statusSelectLocation: 'Standort wählen und Verbinden drücken',
+      statusFailed: 'Proxy konnte nicht gestartet werden',
+      statusStopping: 'Beenden...',
+      statusStopped: 'Proxy gestoppt',
+      proxyDomainsHeading: 'Proxy-Domains',
+      domainPlaceholder: 'example.com',
+      addDomainBtn: 'Domain hinzufügen'
+    }
+  }
+};
+
+export function getMessage(lang, key) {
+  return (LANGS[lang] && LANGS[lang].strings[key]) || LANGS.en.strings[key] || key;
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,35 +2,27 @@
   "manifest_version": 3,
   "name": "ShadowChrome",
   "version": "0.1.0",
-  "description": "Chrome extension to connect via ShadowSocks proxy",
+  "description": "Chrome extension to connect via ShadowSocks proxy with domain-based routing",
   "permissions": [
     "storage",
     "proxy",
-    "sockets"
+    "sockets",
+    "alarms"
   ],
-  "host_permissions": [
-    "<all_urls>"
-  ],
-  "sockets": {
-    "tcp": {
-      "connect": "*"
-    }
-  },
+  "host_permissions": ["<all_urls>"],
+  "sockets": { "tcp": { "connect": "*" } },
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "type": "module"
   },
   "action": {
     "default_popup": "popup.html",
     "default_title": "ShadowChrome"
-  }
-}
-{
-  ...
+  },
   "icons": {
     "16": "icons/icon-16.png",
     "32": "icons/icon-32.png",
     "48": "icons/icon-48.png",
     "128": "icons/icon-128.png"
-  },
-  ...
+  }
 }

--- a/src/pac.js
+++ b/src/pac.js
@@ -1,0 +1,23 @@
+export function generatePac(domains, port) {
+  const sorted = [...domains].sort();
+  const lines = [];
+  lines.push('function FindProxyForURL(url, host) {');
+  lines.push('  host = host.toLowerCase();');
+  lines.push('  var list = [' + sorted.map(d => `'${d}'`).join(',') + '];');
+  lines.push('  var left = 0;');
+  lines.push('  var right = list.length - 1;');
+  lines.push('  while (left <= right) {');
+  lines.push('    var mid = (left + right) >> 1;');
+  lines.push('    var d = list[mid];');
+  lines.push('    if (host === d || host.slice(-d.length-1) === "." + d) {');
+  lines.push(`      return "SOCKS5 127.0.0.1:${port}";`);
+  lines.push('    }');
+  lines.push('    if (host > d) left = mid + 1; else right = mid - 1;');
+  lines.push('  }');
+  lines.push('  if (shExpMatch(host, "*.onion") || shExpMatch(host, "*.i2p")) {');
+  lines.push(`    return "SOCKS5 127.0.0.1:${port}";`);
+  lines.push('  }');
+  lines.push('  return "DIRECT";');
+  lines.push('}');
+  return lines.join('\n');
+}

--- a/src/popup.html
+++ b/src/popup.html
@@ -8,14 +8,24 @@
     label { display: block; margin-top: 5px; }
     input, select { width: 100%; }
     button { margin-top: 10px; width: 100%; }
+    ul { list-style: none; padding: 0; }
+    li { display: flex; justify-content: space-between; margin-top: 4px; }
+    li button { width: auto; margin-top: 0; }
   </style>
 </head>
 <body>
-  <label>Access URL <input id="url" type="text" placeholder="ss:// or ssconf://"></label>
-  <label id="location-label" style="display:none;">Location <select id="location"></select></label>
-  <button id="connect">Connect</button>
-  <button id="disconnect">Disconnect</button>
+  <label id="language-label"><span id="language-label-text"></span> <select id="language"></select></label>
+  <label id="access-label"><span id="access-label-text"></span> <input id="url" type="text"></label>
+  <label id="location-label" style="display:none;"><span id="location-label-text"></span> <select id="location"></select></label>
+  <button id="connect"></button>
+  <button id="disconnect"></button>
   <pre id="status"></pre>
+  <section id="domains">
+    <h3 id="domains-heading"></h3>
+    <input id="domain-input" type="text" />
+    <button id="add-domain"></button>
+    <ul id="domain-list"></ul>
+  </section>
   <script type="module" src="popup.js"></script>
 </body>
 </html>

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,12 +1,64 @@
+import { browser } from './browser-api.js';
 import { parseAccessUrl } from './ssConfig.js';
+import Registry from './registry.js';
+import { LANGS, getMessage } from './i18n.js';
 
+const registry = new Registry();
 let parsedConfigs = null;
+let currentLang = 'en';
 
-function loadConfig() {
-  chrome.storage.local.get(['accessUrl'], (cfg) => {
-    if (cfg.accessUrl) {
-      document.getElementById('url').value = cfg.accessUrl;
-    }
+function populateLanguageSelect() {
+  const select = document.getElementById('language');
+  select.innerHTML = '';
+  Object.entries(LANGS).forEach(([code, info]) => {
+    const option = document.createElement('option');
+    option.value = code;
+    option.textContent = `${info.flag} ${info.name}`;
+    if (code === currentLang) option.selected = true;
+    select.appendChild(option);
+  });
+}
+
+function applyTranslations() {
+  document.getElementById('language-label-text').textContent = getMessage(currentLang, 'languageLabel');
+  document.getElementById('access-label-text').textContent = getMessage(currentLang, 'accessUrlLabel');
+  document.getElementById('url').placeholder = getMessage(currentLang, 'accessUrlPlaceholder');
+  document.getElementById('location-label-text').textContent = getMessage(currentLang, 'locationLabel');
+  document.getElementById('connect').textContent = getMessage(currentLang, 'connectBtn');
+  document.getElementById('disconnect').textContent = getMessage(currentLang, 'disconnectBtn');
+  document.getElementById('domains-heading').textContent = getMessage(currentLang, 'proxyDomainsHeading');
+  document.getElementById('domain-input').placeholder = getMessage(currentLang, 'domainPlaceholder');
+  document.getElementById('add-domain').textContent = getMessage(currentLang, 'addDomainBtn');
+}
+
+async function loadConfig() {
+  const cfg = await browser.storage.local.get(['accessUrl', 'lang']);
+  if (cfg.lang && LANGS[cfg.lang]) {
+    currentLang = cfg.lang;
+  }
+  populateLanguageSelect();
+  applyTranslations();
+  if (cfg.accessUrl) {
+    document.getElementById('url').value = cfg.accessUrl;
+  }
+  renderDomains();
+}
+
+async function renderDomains() {
+  const list = await registry.getDomains();
+  const ul = document.getElementById('domain-list');
+  ul.innerHTML = '';
+  list.forEach(d => {
+    const li = document.createElement('li');
+    li.textContent = d;
+    const btn = document.createElement('button');
+    btn.textContent = '✕';
+    btn.addEventListener('click', async () => {
+      await registry.removeDomain(d);
+      renderDomains();
+    });
+    li.appendChild(btn);
+    ul.appendChild(li);
   });
 }
 
@@ -25,6 +77,12 @@ function showLocations(configs) {
 
 document.addEventListener('DOMContentLoaded', loadConfig);
 
+document.getElementById('language').addEventListener('change', async (e) => {
+  currentLang = e.target.value;
+  await browser.storage.local.set({ lang: currentLang });
+  applyTranslations();
+});
+
 document.getElementById('url').addEventListener('input', () => {
   parsedConfigs = null;
   document.getElementById('location-label').style.display = 'none';
@@ -34,17 +92,17 @@ document.getElementById('connect').addEventListener('click', async () => {
   const url = document.getElementById('url').value.trim();
   const status = document.getElementById('status');
   const locSelect = document.getElementById('location');
-  status.textContent = 'Starting proxy...';
+  status.textContent = getMessage(currentLang, 'statusStarting');
   try {
     if (parsedConfigs && Array.isArray(parsedConfigs)) {
       const chosen = parsedConfigs[parseInt(locSelect.value, 10)];
       const finalCfg = { ...chosen, localPort: 1080, accessUrl: url };
-      chrome.storage.local.set(finalCfg);
-      chrome.runtime.sendMessage({ type: 'start-proxy', config: finalCfg }, (response) => {
+      browser.storage.local.set(finalCfg);
+      browser.runtime.sendMessage({ type: 'start-proxy', config: finalCfg }, (response) => {
         if (response && response.success) {
-          status.textContent = 'Proxy running on 127.0.0.1:1080';
+          status.textContent = getMessage(currentLang, 'statusRunning');
         } else {
-          status.textContent = 'Error: ' + (response && response.error);
+          status.textContent = getMessage(currentLang, 'statusError') + ' ' + (response && response.error);
         }
       });
       return;
@@ -54,27 +112,34 @@ document.getElementById('connect').addEventListener('click', async () => {
     if (Array.isArray(cfg)) {
       parsedConfigs = cfg;
       showLocations(cfg);
-      status.textContent = 'Select location and press Connect';
+      status.textContent = getMessage(currentLang, 'statusSelectLocation');
       return;
     }
     const finalCfg = { ...cfg, localPort: 1080, accessUrl: url };
-    chrome.storage.local.set(finalCfg);
-    chrome.runtime.sendMessage({ type: 'start-proxy', config: finalCfg }, (response) => {
+    browser.storage.local.set(finalCfg);
+    browser.runtime.sendMessage({ type: 'start-proxy', config: finalCfg }, (response) => {
       if (response && response.success) {
-        status.textContent = 'Proxy running on 127.0.0.1:1080';
+        status.textContent = getMessage(currentLang, 'statusRunning');
       } else {
-        status.textContent = 'Error: ' + (response && response.error);
+        status.textContent = getMessage(currentLang, 'statusError') + ' ' + (response && response.error);
       }
     });
   } catch (e) {
-    status.textContent = 'Failed to start proxy';
+    status.textContent = getMessage(currentLang, 'statusFailed');
   }
 });
 
 document.getElementById('disconnect').addEventListener('click', () => {
   const status = document.getElementById('status');
-  status.textContent = 'Stopping...';
-  chrome.runtime.sendMessage({ type: 'stop-proxy' }, () => {
-    status.textContent = 'Proxy stopped';
+  status.textContent = getMessage(currentLang, 'statusStopping');
+  browser.runtime.sendMessage({ type: 'stop-proxy' }, () => {
+    status.textContent = getMessage(currentLang, 'statusStopped');
   });
+});
+
+document.getElementById('add-domain').addEventListener('click', async () => {
+  const input = document.getElementById('domain-input');
+  await registry.addDomain(input.value);
+  input.value = '';
+  renderDomains();
 });

--- a/src/proxyManager.js
+++ b/src/proxyManager.js
@@ -1,0 +1,45 @@
+import { browser, isFirefox, isChrome } from './browser-api.js';
+import { generatePac } from './pac.js';
+
+export default class ProxyManager {
+  constructor(registry) {
+    this.registry = registry;
+    this.currentPacUrl = null;
+    this.enabled = false;
+  }
+
+  async enable(localPort) {
+    const domains = await this.registry.getDomains();
+    const pacScript = generatePac(domains, localPort);
+    if (isFirefox && browser.proxy && browser.proxy.register) {
+      const blob = new Blob([pacScript], { type: 'application/x-ns-proxy-autoconfig' });
+      const url = URL.createObjectURL(blob);
+      await browser.proxy.register(url);
+      this.currentPacUrl = url;
+    } else if (isChrome) {
+      await browser.proxy.settings.set({
+        value: { mode: 'pac_script', pacScript: { data: pacScript } }
+      });
+    }
+    this.enabled = true;
+  }
+
+  async disable() {
+    if (isFirefox && browser.proxy && browser.proxy.unregister) {
+      if (this.currentPacUrl) {
+        await browser.proxy.unregister(this.currentPacUrl);
+        URL.revokeObjectURL(this.currentPacUrl);
+        this.currentPacUrl = null;
+      }
+    } else if (isChrome) {
+      await browser.proxy.settings.clear({});
+    }
+    this.enabled = false;
+  }
+
+  async refresh(localPort) {
+    if (this.enabled) {
+      await this.enable(localPort);
+    }
+  }
+}

--- a/src/registry.js
+++ b/src/registry.js
@@ -1,0 +1,60 @@
+import { browser } from './browser-api.js';
+
+export default class Registry {
+  constructor() {
+    this.key = 'domainRegistry';
+    this.listeners = new Set();
+  }
+
+  async getDomains() {
+    const data = await browser.storage.local.get({ [this.key]: [] });
+    const list = Array.isArray(data[this.key]) ? data[this.key] : [];
+    return list;
+  }
+
+  async setDomains(domains) {
+    await browser.storage.local.set({ [this.key]: domains });
+    this.emit();
+  }
+
+  async addDomain(domain) {
+    const normalized = domain.trim().toLowerCase();
+    if (!normalized) return this.getDomains();
+    const list = await this.getDomains();
+    if (!list.includes(normalized)) {
+      list.push(normalized);
+      list.sort();
+      await this.setDomains(list);
+    }
+    return list;
+  }
+
+  async removeDomain(domain) {
+    const list = await this.getDomains();
+    const filtered = list.filter(d => d !== domain);
+    await this.setDomains(filtered);
+    return filtered;
+  }
+
+  async clear() {
+    await this.setDomains([]);
+  }
+
+  onChange(fn) {
+    this.listeners.add(fn);
+  }
+
+  offChange(fn) {
+    this.listeners.delete(fn);
+  }
+
+  emit() {
+    for (const fn of this.listeners) {
+      try {
+        fn();
+      } catch (e) {
+        console.error('Registry listener failed', e);
+      }
+    }
+  }
+}

--- a/src/serverClient.js
+++ b/src/serverClient.js
@@ -1,0 +1,55 @@
+import { browser } from './browser-api.js';
+
+export default class ServerClient {
+  constructor(registry, mirrors = []) {
+    this.registry = registry;
+    this.mirrors = mirrors;
+    this.alarmName = 'shadowchrome-sync';
+  }
+
+  async fetchFromMirrors(path) {
+    for (const base of this.mirrors) {
+      try {
+        const resp = await fetch(base + path, { cache: 'no-store' });
+        if (resp.ok) {
+          return await resp.json();
+        }
+      } catch (e) {
+        // ignore and continue
+      }
+    }
+    throw new Error('All mirrors failed');
+  }
+
+  async updateRegistry() {
+    try {
+      const data = await this.fetchFromMirrors('/domains.json');
+      if (Array.isArray(data)) {
+        await this.registry.setDomains(data);
+      }
+    } catch (e) {
+      console.warn('Registry update failed', e);
+    }
+  }
+
+  async updateConfig() {
+    try {
+      const cfg = await this.fetchFromMirrors('/config.json');
+      if (cfg && typeof cfg === 'object') {
+        await browser.storage.local.set({ remoteConfig: cfg });
+      }
+    } catch (e) {
+      console.warn('Config update failed', e);
+    }
+  }
+
+  scheduleUpdates() {
+    browser.alarms.create(this.alarmName, { periodInMinutes: 60 });
+    browser.alarms.onAlarm.addListener(alarm => {
+      if (alarm.name === this.alarmName) {
+        this.updateRegistry();
+        this.updateConfig();
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- introduce cross-browser API wrapper with async helpers
- add domain registry, PAC generator and proxy manager
- extend background service to update config from mirrors and manage proxy
- provide UI for editing proxied domains and refresh manifest
- enable manual language selection with translations for English, Latvian, Belarusian and German

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688f147949e08322aa446f4297b2f8b9