### PR TITLE
Add registry-driven PAC proxy and cross-browser support

### DIFF
--- a/src/browser-api.js
+++ b/src/browser-api.js
@@ -1,0 +1,33 @@
+export const isFirefox =
+  typeof globalThis.browser !== 'undefined' && !!globalThis.browser.runtime;
+export const isChrome =
+  typeof globalThis.chrome !== 'undefined' && !!globalThis.chrome.runtime && !isFirefox;
+
+export const browser = isFirefox ? globalThis.browser : globalThis.chrome;
+
+// Utility wrappers used across the project to provide consistent Promise-based
+// APIs regardless of whether the underlying implementation uses callbacks.
+
+export function asyncMessage(message) {
+  return new Promise(resolve => {
+    browser.runtime.sendMessage(message, resolve);
+  });
+}
+
+export function getFromStorage(keys) {
+  return new Promise(resolve => {
+    browser.storage.local.get(keys, resolve);
+  });
+}
+
+export function setInStorage(obj) {
+  return new Promise(resolve => {
+    browser.storage.local.set(obj, resolve);
+  });
+}
+
+export function removeFromStorage(keys) {
+  return new Promise(resolve => {
+    browser.storage.local.remove(keys, resolve);
+  });
+}

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,92 @@
+import { getFromStorage, setInStorage } from './browser-api.js';
+
+export const LANGUAGES = {
+  en: {
+    label: 'English \uD83C\uDDFA\uD83C\uDDF8',
+    strings: {
+      language: 'Language',
+      accessUrl: 'Access URL',
+      location: 'Location',
+      connect: 'Connect',
+      disconnect: 'Disconnect',
+      proxyDomains: 'Proxy Domains',
+      addDomain: 'Add Domain',
+      starting: 'Starting proxy...',
+      running: 'Proxy running on 127.0.0.1:1080',
+      error: 'Error: ',
+      selectLocation: 'Select location and press Connect',
+      failed: 'Failed to start proxy',
+      stopping: 'Stopping...',
+      stopped: 'Proxy stopped'
+    }
+  },
+  lv: {
+    label: 'Latviešu \uD83C\uDDF1\uD83C\uDDFB',
+    strings: {
+      language: 'Valoda',
+      accessUrl: 'Piek\u013Cuves URL',
+      location: 'Atra\u0161an\u0101s vieta',
+      connect: 'Piesl\u0113gties',
+      disconnect: 'Atvienot',
+      proxyDomains: 'Proxy dom\u0113ni',
+      addDomain: 'Pievienot dom\u0113nu',
+      starting: 'Start\u0113 proksi...',
+      running: 'Proksi darbojas uz 127.0.0.1:1080',
+      error: 'K\u013C\u016Bda: ',
+      selectLocation: 'Izv\u0113lieties atra\u0161an\u0101s vietu un spiediet Piesl\u0113gties',
+      failed: 'Neizdev\u0101s start\u0113t proksi',
+      stopping: 'Aptur proksi...',
+      stopped: 'Proksi aptur\u0113ts'
+    }
+  },
+  be: {
+    label: '\u0411\u0435\u043B\u0430\u0440\u0443\u0441\u043A\u0430\u044F \uD83C\uDDE7\uD83C\uDDFE',
+    strings: {
+      language: '\u041C\u043E\u0432\u0430',
+      accessUrl: 'URL \u0434\u043E\u0441\u0442\u0443\u043F\u0443',
+      location: '\u0420\u0430\u0437\u043C\u044F\u0448\u0447\u044D\u043D\u043D\u0435',
+      connect: '\u041F\u0430\u0434\u043A\u043B\u044E\u0447\u044B\u0446\u0446\u0430',
+      disconnect: '\u0410\u0434\u043A\u043B\u044E\u0447\u044B\u0446\u0446\u0430',
+      proxyDomains: '\u041F\u0440\u043E\u043A\u0441\u0456 \u0434\u0430\u043C\u0435\u043D\u044B',
+      addDomain: '\u0414\u0430\u0434\u0430\u0446\u044C \u0434\u0430\u043C\u0435\u043D',
+      starting: '\u0417\u0430\u043F\u0443\u0441\u043A\u0430\u0435\u0446\u0446\u0430 \u043F\u0440\u043E\u043A\u0441\u0456...',
+      running: '\u041F\u0440\u043E\u043A\u0441\u0456 \u043F\u0440\u0430\u0446\u0443\u0435 \u043D\u0430 127.0.0.1:1080',
+      error: '\u041F\u0430\u043C\u044B\u043B\u043A\u0430: ',
+      selectLocation: '\u0412\u044B\u0431\u0435\u0440\u0446\u0435 \u0440\u0430\u0437\u043C\u044F\u0448\u0447\u044D\u043D\u043D\u0435 \u0456 \u043D\u0430\u0446\u0456\u0441\u043D\u0456\u0446\u0435 \u041F\u0430\u0434\u043A\u043B\u044E\u0447\u044B\u0446\u0446\u0430',
+      failed: '\u041D\u0435 \u045E\u0434\u0430\u043B\u043E\u0441\u044F \u0437\u0430\u043F\u0443\u0441\u0446\u0456 \u043F\u0440\u043E\u043A\u0441\u0456',
+      stopping: '\u0421\u043F\u044B\u043D\u044F\u0435\u043C...',
+      stopped: '\u041F\u0440\u043E\u043A\u0441\u0456 \u0441\u043F\u044B\u043D\u0435\u043D\u044B'
+    }
+  },
+  de: {
+    label: 'Deutsch \uD83C\uDDE9\uD83C\uDDEA',
+    strings: {
+      language: 'Sprache',
+      accessUrl: 'Zugangs-URL',
+      location: 'Standort',
+      connect: 'Verbinden',
+      disconnect: 'Trennen',
+      proxyDomains: 'Proxy-Domains',
+      addDomain: 'Domain hinzuf\u00FCgen',
+      starting: 'Proxy wird gestartet...',
+      running: 'Proxy l\u00E4uft auf 127.0.0.1:1080',
+      error: 'Fehler: ',
+      selectLocation: 'Standort ausw\u00E4hlen und Verbinden dr\u00FCcken',
+      failed: 'Proxy konnte nicht gestartet werden',
+      stopping: 'Beenden...',
+      stopped: 'Proxy gestoppt'
+    }
+  }
+};
+
+const DEFAULT_LANG = 'en';
+
+export async function loadLanguage() {
+  const { lang } = await getFromStorage(['lang']);
+  return lang && LANGUAGES[lang] ? lang : DEFAULT_LANG;
+}
+
+export function setLanguage(lang) {
+  return setInStorage({ lang });
+}
+

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,35 +2,27 @@
   "manifest_version": 3,
   "name": "ShadowChrome",
   "version": "0.1.0",
-  "description": "Chrome extension to connect via ShadowSocks proxy",
+  "description": "Chrome extension to connect via ShadowSocks proxy with domain-based routing",
   "permissions": [
     "storage",
     "proxy",
-    "sockets"
+    "sockets",
+    "alarms"
   ],
-  "host_permissions": [
-    "<all_urls>"
-  ],
-  "sockets": {
-    "tcp": {
-      "connect": "*"
-    }
-  },
+  "host_permissions": ["<all_urls>"],
+  "sockets": { "tcp": { "connect": "*" } },
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "type": "module"
   },
   "action": {
     "default_popup": "popup.html",
     "default_title": "ShadowChrome"
-  }
-}
-{
-  ...
+  },
   "icons": {
     "16": "icons/icon-16.png",
     "32": "icons/icon-32.png",
     "48": "icons/icon-48.png",
     "128": "icons/icon-128.png"
-  },
-  ...
+  }
 }

--- a/src/pac.js
+++ b/src/pac.js
@@ -1,0 +1,23 @@
+export function generatePac(domains, port) {
+  const sorted = [...domains].sort();
+  const lines = [];
+  lines.push('function FindProxyForURL(url, host) {');
+  lines.push('  host = host.toLowerCase();');
+  lines.push('  var list = [' + sorted.map(d => `'${d}'`).join(',') + '];');
+  lines.push('  var left = 0;');
+  lines.push('  var right = list.length - 1;');
+  lines.push('  while (left <= right) {');
+  lines.push('    var mid = (left + right) >> 1;');
+  lines.push('    var d = list[mid];');
+  lines.push('    if (host === d || host.slice(-d.length-1) === "." + d) {');
+  lines.push(`      return "SOCKS5 127.0.0.1:${port}";`);
+  lines.push('    }');
+  lines.push('    if (host > d) left = mid + 1; else right = mid - 1;');
+  lines.push('  }');
+  lines.push('  if (shExpMatch(host, "*.onion") || shExpMatch(host, "*.i2p")) {');
+  lines.push(`    return "SOCKS5 127.0.0.1:${port}";`);
+  lines.push('  }');
+  lines.push('  return "DIRECT";');
+  lines.push('}');
+  return lines.join('\n');
+}

--- a/src/popup.html
+++ b/src/popup.html
@@ -8,14 +8,24 @@
     label { display: block; margin-top: 5px; }
     input, select { width: 100%; }
     button { margin-top: 10px; width: 100%; }
+    ul { list-style: none; padding: 0; }
+    li { display: flex; justify-content: space-between; margin-top: 4px; }
+    li button { width: auto; margin-top: 0; }
   </style>
 </head>
 <body>
-  <label>Access URL <input id="url" type="text" placeholder="ss:// or ssconf://"></label>
+  <label id="language-label">Language <select id="language"></select></label>
+  <label id="url-label">Access URL <input id="url" type="text" placeholder="ss:// or ssconf://"></label>
   <label id="location-label" style="display:none;">Location <select id="location"></select></label>
   <button id="connect">Connect</button>
   <button id="disconnect">Disconnect</button>
   <pre id="status"></pre>
+  <section id="domains">
+    <h3 id="domains-title">Proxy Domains</h3>
+    <input id="domain-input" type="text" placeholder="example.com" />
+    <button id="add-domain">Add Domain</button>
+    <ul id="domain-list"></ul>
+  </section>
   <script type="module" src="popup.js"></script>
 </body>
 </html>

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,12 +1,35 @@
+import { browser } from './browser-api.js';
 import { parseAccessUrl } from './ssConfig.js';
+import Registry from './registry.js';
+import { LANGUAGES, loadLanguage, setLanguage } from './i18n.js';
 
+const registry = new Registry();
 let parsedConfigs = null;
+let currentLang = 'en';
 
-function loadConfig() {
-  chrome.storage.local.get(['accessUrl'], (cfg) => {
-    if (cfg.accessUrl) {
-      document.getElementById('url').value = cfg.accessUrl;
-    }
+async function loadConfig() {
+  const cfg = await browser.storage.local.get(['accessUrl']);
+  if (cfg.accessUrl) {
+    document.getElementById('url').value = cfg.accessUrl;
+  }
+  renderDomains();
+}
+
+async function renderDomains() {
+  const list = await registry.getDomains();
+  const ul = document.getElementById('domain-list');
+  ul.innerHTML = '';
+  list.forEach(d => {
+    const li = document.createElement('li');
+    li.textContent = d;
+    const btn = document.createElement('button');
+    btn.textContent = '✕';
+    btn.addEventListener('click', async () => {
+      await registry.removeDomain(d);
+      renderDomains();
+    });
+    li.appendChild(btn);
+    ul.appendChild(li);
   });
 }
 
@@ -23,7 +46,43 @@ function showLocations(configs) {
   label.style.display = 'block';
 }
 
-document.addEventListener('DOMContentLoaded', loadConfig);
+function applyTranslations(lang) {
+  currentLang = lang;
+  const strings = LANGUAGES[lang].strings;
+  document.getElementById('language-label').childNodes[0].nodeValue = strings.language + ' ';
+  document.getElementById('url-label').childNodes[0].nodeValue = strings.accessUrl + ' ';
+  document.getElementById('location-label').childNodes[0].nodeValue = strings.location + ' ';
+  document.getElementById('connect').textContent = strings.connect;
+  document.getElementById('disconnect').textContent = strings.disconnect;
+  document.getElementById('domains-title').textContent = strings.proxyDomains;
+  document.getElementById('add-domain').textContent = strings.addDomain;
+}
+
+function setupLanguageSelect(lang) {
+  const select = document.getElementById('language');
+  select.innerHTML = '';
+  Object.entries(LANGUAGES).forEach(([code, data]) => {
+    const option = document.createElement('option');
+    option.value = code;
+    option.textContent = data.label;
+    if (code === lang) {
+      option.selected = true;
+    }
+    select.appendChild(option);
+  });
+  select.addEventListener('change', async () => {
+    const newLang = select.value;
+    await setLanguage(newLang);
+    applyTranslations(newLang);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  await loadConfig();
+  const lang = await loadLanguage();
+  setupLanguageSelect(lang);
+  applyTranslations(lang);
+});
 
 document.getElementById('url').addEventListener('input', () => {
   parsedConfigs = null;
@@ -34,17 +93,18 @@ document.getElementById('connect').addEventListener('click', async () => {
   const url = document.getElementById('url').value.trim();
   const status = document.getElementById('status');
   const locSelect = document.getElementById('location');
-  status.textContent = 'Starting proxy...';
+  const strings = LANGUAGES[currentLang].strings;
+  status.textContent = strings.starting;
   try {
     if (parsedConfigs && Array.isArray(parsedConfigs)) {
       const chosen = parsedConfigs[parseInt(locSelect.value, 10)];
       const finalCfg = { ...chosen, localPort: 1080, accessUrl: url };
-      chrome.storage.local.set(finalCfg);
-      chrome.runtime.sendMessage({ type: 'start-proxy', config: finalCfg }, (response) => {
+      browser.storage.local.set(finalCfg);
+      browser.runtime.sendMessage({ type: 'start-proxy', config: finalCfg }, (response) => {
         if (response && response.success) {
-          status.textContent = 'Proxy running on 127.0.0.1:1080';
+          status.textContent = strings.running;
         } else {
-          status.textContent = 'Error: ' + (response && response.error);
+          status.textContent = strings.error + (response && response.error);
         }
       });
       return;
@@ -54,27 +114,35 @@ document.getElementById('connect').addEventListener('click', async () => {
     if (Array.isArray(cfg)) {
       parsedConfigs = cfg;
       showLocations(cfg);
-      status.textContent = 'Select location and press Connect';
+      status.textContent = strings.selectLocation;
       return;
     }
     const finalCfg = { ...cfg, localPort: 1080, accessUrl: url };
-    chrome.storage.local.set(finalCfg);
-    chrome.runtime.sendMessage({ type: 'start-proxy', config: finalCfg }, (response) => {
+    browser.storage.local.set(finalCfg);
+    browser.runtime.sendMessage({ type: 'start-proxy', config: finalCfg }, (response) => {
       if (response && response.success) {
-        status.textContent = 'Proxy running on 127.0.0.1:1080';
+        status.textContent = strings.running;
       } else {
-        status.textContent = 'Error: ' + (response && response.error);
+        status.textContent = strings.error + (response && response.error);
       }
     });
   } catch (e) {
-    status.textContent = 'Failed to start proxy';
+    status.textContent = strings.failed;
   }
 });
 
 document.getElementById('disconnect').addEventListener('click', () => {
   const status = document.getElementById('status');
-  status.textContent = 'Stopping...';
-  chrome.runtime.sendMessage({ type: 'stop-proxy' }, () => {
-    status.textContent = 'Proxy stopped';
+  const strings = LANGUAGES[currentLang].strings;
+  status.textContent = strings.stopping;
+  browser.runtime.sendMessage({ type: 'stop-proxy' }, () => {
+    status.textContent = strings.stopped;
   });
+});
+
+document.getElementById('add-domain').addEventListener('click', async () => {
+  const input = document.getElementById('domain-input');
+  await registry.addDomain(input.value);
+  input.value = '';
+  renderDomains();
 });

--- a/src/proxyManager.js
+++ b/src/proxyManager.js
@@ -1,0 +1,45 @@
+import { browser, isFirefox, isChrome } from './browser-api.js';
+import { generatePac } from './pac.js';
+
+export default class ProxyManager {
+  constructor(registry) {
+    this.registry = registry;
+    this.currentPacUrl = null;
+    this.enabled = false;
+  }
+
+  async enable(localPort) {
+    const domains = await this.registry.getDomains();
+    const pacScript = generatePac(domains, localPort);
+    if (isFirefox && browser.proxy && browser.proxy.register) {
+      const blob = new Blob([pacScript], { type: 'application/x-ns-proxy-autoconfig' });
+      const url = URL.createObjectURL(blob);
+      await browser.proxy.register(url);
+      this.currentPacUrl = url;
+    } else if (isChrome) {
+      await browser.proxy.settings.set({
+        value: { mode: 'pac_script', pacScript: { data: pacScript } }
+      });
+    }
+    this.enabled = true;
+  }
+
+  async disable() {
+    if (isFirefox && browser.proxy && browser.proxy.unregister) {
+      if (this.currentPacUrl) {
+        await browser.proxy.unregister(this.currentPacUrl);
+        URL.revokeObjectURL(this.currentPacUrl);
+        this.currentPacUrl = null;
+      }
+    } else if (isChrome) {
+      await browser.proxy.settings.clear({});
+    }
+    this.enabled = false;
+  }
+
+  async refresh(localPort) {
+    if (this.enabled) {
+      await this.enable(localPort);
+    }
+  }
+}

--- a/src/registry.js
+++ b/src/registry.js
@@ -1,0 +1,60 @@
+import { browser } from './browser-api.js';
+
+export default class Registry {
+  constructor() {
+    this.key = 'domainRegistry';
+    this.listeners = new Set();
+  }
+
+  async getDomains() {
+    const data = await browser.storage.local.get({ [this.key]: [] });
+    const list = Array.isArray(data[this.key]) ? data[this.key] : [];
+    return list;
+  }
+
+  async setDomains(domains) {
+    await browser.storage.local.set({ [this.key]: domains });
+    this.emit();
+  }
+
+  async addDomain(domain) {
+    const normalized = domain.trim().toLowerCase();
+    if (!normalized) return this.getDomains();
+    const list = await this.getDomains();
+    if (!list.includes(normalized)) {
+      list.push(normalized);
+      list.sort();
+      await this.setDomains(list);
+    }
+    return list;
+  }
+
+  async removeDomain(domain) {
+    const list = await this.getDomains();
+    const filtered = list.filter(d => d !== domain);
+    await this.setDomains(filtered);
+    return filtered;
+  }
+
+  async clear() {
+    await this.setDomains([]);
+  }
+
+  onChange(fn) {
+    this.listeners.add(fn);
+  }
+
+  offChange(fn) {
+    this.listeners.delete(fn);
+  }
+
+  emit() {
+    for (const fn of this.listeners) {
+      try {
+        fn();
+      } catch (e) {
+        console.error('Registry listener failed', e);
+      }
+    }
+  }
+}

--- a/src/serverClient.js
+++ b/src/serverClient.js
@@ -1,0 +1,55 @@
+import { browser } from './browser-api.js';
+
+export default class ServerClient {
+  constructor(registry, mirrors = []) {
+    this.registry = registry;
+    this.mirrors = mirrors;
+    this.alarmName = 'shadowchrome-sync';
+  }
+
+  async fetchFromMirrors(path) {
+    for (const base of this.mirrors) {
+      try {
+        const resp = await fetch(base + path, { cache: 'no-store' });
+        if (resp.ok) {
+          return await resp.json();
+        }
+      } catch (e) {
+        // ignore and continue
+      }
+    }
+    throw new Error('All mirrors failed');
+  }
+
+  async updateRegistry() {
+    try {
+      const data = await this.fetchFromMirrors('/domains.json');
+      if (Array.isArray(data)) {
+        await this.registry.setDomains(data);
+      }
+    } catch (e) {
+      console.warn('Registry update failed', e);
+    }
+  }
+
+  async updateConfig() {
+    try {
+      const cfg = await this.fetchFromMirrors('/config.json');
+      if (cfg && typeof cfg === 'object') {
+        await browser.storage.local.set({ remoteConfig: cfg });
+      }
+    } catch (e) {
+      console.warn('Config update failed', e);
+    }
+  }
+
+  scheduleUpdates() {
+    browser.alarms.create(this.alarmName, { periodInMinutes: 60 });
+    browser.alarms.onAlarm.addListener(alarm => {
+      if (alarm.name === this.alarmName) {
+        this.updateRegistry();
+        this.updateConfig();
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- introduce cross-browser API wrapper with async helpers
- add domain registry, PAC generator and proxy manager
- extend background service to update config from mirrors and manage proxy
- provide UI for editing proxied domains and refresh manifest
- add manual language selector with English, Latvian, Belarusian and German translations

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688f147949e08322aa446f4297b2f8b9