### PR TITLE
feat: add sync utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "lint": "eslint src/*.js",
+    "lint": "eslint \"src/**/*.js\"",
     "list": "node scripts/listActions.mjs"
   },
   "devDependencies": {

--- a/src/background.js
+++ b/src/background.js
@@ -315,5 +315,11 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
         .catch(e => sendResponse({ success: false, error: e.message }));
     });
     return true;
+  } else if (message.type === 'sync') {
+    serverClient
+      .syncAll()
+      .then(() => sendResponse({ success: true }))
+      .catch(e => sendResponse({ success: false, error: e.message }));
+    return true;
   }
 });

--- a/src/popup.html
+++ b/src/popup.html
@@ -24,6 +24,7 @@
   <label id="location-label" style="display:none;"><span id="location-label-text">Location</span> <select id="location"></select></label>
   <button id="connect">Connect</button>
   <button id="disconnect">Disconnect</button>
+  <button id="sync">Sync</button>
   <pre id="status"></pre>
   <section id="domains">
     <h3 id="domains-title">Proxy Domains</h3>

--- a/src/popup.js
+++ b/src/popup.js
@@ -14,6 +14,7 @@ const translations = {
     location: 'Location',
     connect: 'Connect',
     disconnect: 'Disconnect',
+    sync: 'Sync',
     proxyDomains: 'Proxy Domains',
     addDomain: 'Add Domain',
     domainPlaceholder: 'example.com',
@@ -23,7 +24,9 @@ const translations = {
     selectLocation: 'Select location and press Connect',
     failedStart: 'Failed to start proxy',
     stopping: 'Stopping...',
-    proxyStopped: 'Proxy stopped'
+    proxyStopped: 'Proxy stopped',
+    syncing: 'Syncing...',
+    syncComplete: 'Sync complete'
   },
   lv: {
     language: 'Valoda',
@@ -32,6 +35,7 @@ const translations = {
     location: 'Atrašanās vieta',
     connect: 'Pievienoties',
     disconnect: 'Atvienoties',
+    sync: 'Sinhronizēt',
     proxyDomains: 'Starpniekservera domēni',
     addDomain: 'Pievienot domēnu',
     domainPlaceholder: 'example.com',
@@ -41,7 +45,9 @@ const translations = {
     selectLocation: "Izvēlieties atrašanās vietu un nospiediet 'Pievienoties'",
     failedStart: 'Neizdevās startēt starpniekserveri',
     stopping: 'Apstādināšana...',
-    proxyStopped: 'Starpniekserveris apstādināts'
+    proxyStopped: 'Starpniekserveris apstādināts',
+    syncing: 'Sinhronizācija...',
+    syncComplete: 'Sinhronizācija pabeigta'
   },
   be: {
     language: 'Мова',
@@ -50,6 +56,7 @@ const translations = {
     location: 'Месцазнаходжанне',
     connect: 'Падключыць',
     disconnect: 'Адключыць',
+    sync: 'Сінхранізаваць',
     proxyDomains: 'Дамены праксі',
     addDomain: 'Дадаць дамен',
     domainPlaceholder: 'example.com',
@@ -59,7 +66,9 @@ const translations = {
     selectLocation: 'Выберыце месцазнаходжанне і націсніце "Падключыць"',
     failedStart: 'Не атрымалася запусціць праксі',
     stopping: 'Спыненне...',
-    proxyStopped: 'Праксі спынены'
+    proxyStopped: 'Праксі спынены',
+    syncing: 'Сінхранізацыя...',
+    syncComplete: 'Сінхранізацыя завершана'
   },
   de: {
     language: 'Sprache',
@@ -68,6 +77,7 @@ const translations = {
     location: 'Standort',
     connect: 'Verbinden',
     disconnect: 'Trennen',
+    sync: 'Synchronisieren',
     proxyDomains: 'Proxy-Domains',
     addDomain: 'Domain hinzufügen',
     domainPlaceholder: 'example.com',
@@ -77,7 +87,9 @@ const translations = {
     selectLocation: 'Standort wählen und auf "Verbinden" klicken',
     failedStart: 'Proxy konnte nicht gestartet werden',
     stopping: 'Wird gestoppt...',
-    proxyStopped: 'Proxy gestoppt'
+    proxyStopped: 'Proxy gestoppt',
+    syncing: 'Synchronisiere...',
+    syncComplete: 'Synchronisierung abgeschlossen'
   }
 };
 
@@ -89,6 +101,7 @@ function applyTranslations() {
   document.getElementById('location-label-text').textContent = t.location;
   document.getElementById('connect').textContent = t.connect;
   document.getElementById('disconnect').textContent = t.disconnect;
+  document.getElementById('sync').textContent = t.sync;
   document.getElementById('domains-title').textContent = t.proxyDomains;
   document.getElementById('add-domain').textContent = t.addDomain;
   document.getElementById('domain-input').placeholder = t.domainPlaceholder;
@@ -200,6 +213,19 @@ document.getElementById('disconnect').addEventListener('click', () => {
   status.textContent = translations[currentLang].stopping;
   browser.runtime.sendMessage({ type: 'stop-proxy' }, () => {
     status.textContent = translations[currentLang].proxyStopped;
+  });
+});
+
+document.getElementById('sync').addEventListener('click', () => {
+  const status = document.getElementById('status');
+  status.textContent = translations[currentLang].syncing;
+  browser.runtime.sendMessage({ type: 'sync' }, response => {
+    if (response && response.success) {
+      status.textContent = translations[currentLang].syncComplete;
+    } else {
+      status.textContent =
+        translations[currentLang].error + (response && response.error);
+    }
   });
 });
 

--- a/src/utils/daysToRenewal.js
+++ b/src/utils/daysToRenewal.js
@@ -1,19 +1,37 @@
 /**
  * Calculates the number of whole days remaining until the renewal date.
- * Dates are normalised to UTC to avoid daylight‑saving issues.
+ * Dates are normalised to UTC to avoid daylight-saving issues.
  *
- * @param {Date} curDate - The current date.
+ * @param {Date|string} curDate - Current date or date string.
+ * @param {Date|string} renewalDate - Renewal date or date string.
+ * @returns {number} Non-negative number of days until renewal.
  */
 export function daysToRenewal(curDate, renewalDate) {
-const renew = new Date(renewalDate);
+  const start = new Date(curDate);
+  const renew = new Date(renewalDate);
 
-const startUtc = Date.UTC(
-curDate.getFullYear(),
-curDate.getMonth(),
-curDate.getDate()
-);
-const endUtc = Date.UTC(renew.getFullYear(), renew.getMonth(), renew.getDate());
+  const startUtc = Date.UTC(
+    start.getFullYear(),
+    start.getMonth(),
+    start.getDate()
+  );
+  const endUtc = Date.UTC(
+    renew.getFullYear(),
+    renew.getMonth(),
+    renew.getDate()
+  );
 
-const diffDays = Math.floor((endUtc - startUtc) / 86400000);
-return diffDays > 0 ? diffDays : 0;
+  const diffDays = Math.floor((endUtc - startUtc) / 86400000);
+  return diffDays > 0 ? diffDays : 0;
+}
+
+/**
+ * Determines whether the renewal date has already passed.
+ *
+ * @param {Date|string} curDate - Current date or date string.
+ * @param {Date|string} renewalDate - Renewal date or date string.
+ * @returns {boolean} True if the renewal date is in the past.
+ */
+export function isExpired(curDate, renewalDate) {
+  return new Date(curDate) > new Date(renewalDate);
 }

--- a/src/utils/withTimeout.js
+++ b/src/utils/withTimeout.js
@@ -1,0 +1,29 @@
+/**
+ * Wraps a promise with a timeout. If the promise does not settle within the
+ * specified duration, the returned promise rejects.
+ *
+ * @template T
+ * @param {Promise<T>} promise - The promise to wrap.
+ * @param {number} ms - Timeout in milliseconds.
+ * @param {string} [message='Operation timed out'] - Error message on timeout.
+ * @returns {Promise<T>} A promise that resolves or rejects with the original
+ *   promise's outcome, or rejects if the timeout is reached first.
+ */
+export function withTimeout(promise, ms, message = 'Operation timed out') {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(message));
+    }, ms);
+
+    promise.then(
+      value => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      err => {
+        clearTimeout(timer);
+        reject(err);
+      }
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- add manual configuration sync button with translations
- introduce fetch timeout helper and server sync support
- clean up date utilities and lint entire src tree

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f65c33ae883228804552c8ff9dd95