### PR TITLE
Harden background startup error handling

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -41,14 +41,21 @@ async function bootstrapDomains() {
   }
 }
 
-bootstrapDomains();
+bootstrapDomains().catch(error => logger.error('Failed to bootstrap domains', error));
 
-logger.load().then(() => logger.info('Background script initialized'));
+logger
+  .load()
+  .then(() => logger.info('Background script initialized'))
+  .catch(error => logger.error('Failed to load persisted logs', error));
 
 browser.storage.onChanged.addListener(async (changes, area) => {
   if (area === 'local' && (changes.domainRegistry || changes.registryState)) {
     const port = proxyConfig ? proxyConfig.localPort : 1080;
-    await proxyManager.refresh(port);
+    try {
+      await proxyManager.refresh(port);
+    } catch (error) {
+      logger.error('Failed to refresh proxy after registry change', error);
+    }
   }
 });
 


### PR DESCRIPTION
## Summary
- add error handling around background bootstrap and log loading to avoid unhandled rejections
- guard proxy refresh updates triggered by registry storage changes with logged error handling

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b2eac98988322a92a674268190d8a)